### PR TITLE
Tags validation & auto-adding

### DIFF
--- a/src/components/notifications/Notifications.tsx
+++ b/src/components/notifications/Notifications.tsx
@@ -2,18 +2,19 @@ import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { OpenTrappState } from '../../redux/root.reducer';
 import { Snackbar } from '@material-ui/core';
+import {dismissNotification} from "../../redux/notifications.actions";
 
 export const Notifications = () => {
   const notifications = useSelector((state: OpenTrappState) => state.notifications.notifications);
   const dispatch = useDispatch();
-  const dismissNotification = (id: string) => dispatch(dismissNotification(id));
+  const dissmiss = (id: string) => dispatch(dismissNotification(id));
 
   return (
       <div>
         {notifications.map((notification, idx) =>
             <Snackbar key={idx}
                       open={true}
-                      onClose={() => dismissNotification(notification.id)}
+                      onClose={() => dissmiss(notification.id)}
                       message={notification.message}
                       anchorOrigin={{vertical: 'bottom', horizontal: 'right'}}/>
         )}

--- a/src/components/registrationPage/RegistrationPage.desktop.tsx
+++ b/src/components/registrationPage/RegistrationPage.desktop.tsx
@@ -16,6 +16,7 @@ import { ParsedWorkLog } from '../../workLogExpressionParser/ParsedWorkLog';
 import { changeWorkLog, loadPresets, saveWorkLog } from '../../redux/registration.actions';
 import { Month } from '../../utils/Month';
 import { Preset } from './registration.model';
+import { extractAutoAddedTagsMapping } from '../../utils/tagUtils'
 
 interface RegistrationPageDataProps {
   selectedMonth: Month;
@@ -36,6 +37,7 @@ interface RegistrationPageEventProps {
 type RegistrationPageProps = RegistrationPageDataProps & RegistrationPageEventProps;
 
 class RegistrationPageDesktopComponent extends Component<RegistrationPageProps, {}> {
+  static readonly AUTO_ADDED_TAGS_MAPPING = extractAutoAddedTagsMapping();
 
   componentDidMount(): void {
     const {init, selectedMonth} = this.props;
@@ -61,7 +63,8 @@ class RegistrationPageDesktopComponent extends Component<RegistrationPageProps, 
                             onSave={onSaveWorkLog}
                             workLog={workLog}
                             tags={tags}
-                            presets={presets}/>
+                            presets={presets}
+                            autoAddedTagsMapping={RegistrationPageDesktopComponent.AUTO_ADDED_TAGS_MAPPING}/>
             </Grid>
             <Grid item lg={10} md={11} xs={11}>
               {days && !isEmpty(workLogs) ?

--- a/src/components/registrationPage/workLogInput/ValidationStatus.scss
+++ b/src/components/registrationPage/workLogInput/ValidationStatus.scss
@@ -1,0 +1,3 @@
+.validation-error {
+  padding: 5px 10px 5px 10px;
+}

--- a/src/components/registrationPage/workLogInput/ValidationStatus.tsx
+++ b/src/components/registrationPage/workLogInput/ValidationStatus.tsx
@@ -1,21 +1,50 @@
 import React from 'react';
-import { isEmpty } from 'lodash';
+import {isEmpty} from 'lodash';
 import ErrorIcon from '@material-ui/icons/Error';
+import './ValidationStatus.scss'
 import OkIcon from '@material-ui/icons/CheckCircle';
-import { ParsedWorkLog } from '../../../workLogExpressionParser/ParsedWorkLog';
+import {ParsedWorkLog} from '../../../workLogExpressionParser/ParsedWorkLog';
+import {Popover, Typography} from "@material-ui/core";
+import IconButton from "@material-ui/core/IconButton";
 
 interface ValidationStatusProps {
     workLog: ParsedWorkLog;
 }
 
 export const ValidationStatus = ({workLog}: ValidationStatusProps) => {
-    if (workLog.valid) {
+
+    const [anchorEl, setAnchorEl] = React.useState(null);
+    const handleClick = (event) => {
+        setAnchorEl(event.currentTarget);
+    };
+
+    const handleClose = () => {
+        setAnchorEl(null);
+    };
+    const open = Boolean(anchorEl);
+    const validationResult = workLog.validate();
+    if (validationResult.valid) {
         return (
-            <OkIcon htmlColor='#5BC440' data-ok-indicator />
+            <OkIcon htmlColor='#5BC440' data-ok-indicator/>
         )
     } else if (!isEmpty(workLog.expression)) {
         return (
-            <ErrorIcon color='error' data-error-indicator />
+            <React.Fragment>
+                <IconButton aria-label='Help' onClick={handleClick} data-error-indicator>
+                    <ErrorIcon color='error'/>
+                </IconButton>
+                <Popover
+                    open={open}
+                    anchorEl={anchorEl}
+                    onClose={handleClose}
+                    anchorOrigin={{vertical: 'bottom', horizontal: 'center'}}
+                    transformOrigin={{vertical: 'top', horizontal: 'center'}}>
+                    {validationResult.errors.map(error => {
+                        return <Typography className='validation-error' key={error}>{error}</Typography>
+                    })
+                    }
+                </Popover>
+            </React.Fragment>
         )
     }
     return null;

--- a/src/components/registrationPage/workLogInput/WorkLogInput.spec.tsx
+++ b/src/components/registrationPage/workLogInput/WorkLogInput.spec.tsx
@@ -48,7 +48,7 @@ describe('WorkLogInput', () => {
     type(wrapper, '1d #projects #nvm');
 
     expect(parsedWorkLog.expression).toEqual('1d #projects #nvm');
-    expect(parsedWorkLog.valid).toBeTruthy();
+    expect(parsedWorkLog.validate().valid).toBeTruthy();
     expect(parsedWorkLog.workload).toEqual('1d');
     expect(parsedWorkLog.tags).toEqual(['projects', 'nvm']);
     expect(parsedWorkLog.days).toEqual([moment().format('YYYY/MM/DD')]);
@@ -65,7 +65,7 @@ describe('WorkLogInput', () => {
     type(wrapper, '1d');
 
     expect(parsedWorkLog.expression).toEqual('1d');
-    expect(parsedWorkLog.valid).toBeFalsy();
+    expect(parsedWorkLog.validate().valid).toBeFalsy();
   });
 
   it('emits save on enter click if valid work log', () => {
@@ -78,7 +78,7 @@ describe('WorkLogInput', () => {
 
     pressEnter(wrapper);
 
-    expect(savePayload.valid).toBeTruthy();
+    expect(savePayload.validate().valid).toBeTruthy();
     expect(savePayload.workload).toEqual('1d');
     expect(savePayload.days).toEqual(['2019/03/01']);
     expect(savePayload.tags).toEqual(['projects', 'nvm']);
@@ -208,7 +208,7 @@ describe('WorkLogInput', () => {
   describe('new tags', () => {
     it('shows confirmation dialog if work log contains new tags', () => {
       const onSave = jest.fn();
-      const initialWorkLog = new ParsedWorkLog('1h #new-tag @2019/03/01', ['2019/03/01'], ['new-tag'], '1h');
+      const initialWorkLog = new ParsedWorkLog('1h #projects #new-tag @2019/03/01', ['2019/03/01'], ['projects', 'new-tag'], '1h');
       const wrapper = mount(
           <WorkLogInput workLog={initialWorkLog} tags={tags} presets={[]} onChange={noop} onSave={onSave}/>
       );
@@ -222,7 +222,8 @@ describe('WorkLogInput', () => {
 
     it('emits save if user confirmed new tags', () => {
       const onSave = jest.fn();
-      const initialWorkLog = new ParsedWorkLog('1h #new-tag @2019/03/01', ['2019/03/01'], ['new-tag'], '1h');
+      const expression = '1h #projects #new-tag @2019/03/01';
+      const initialWorkLog = new ParsedWorkLog(expression, ['2019/03/01'], ['projects', 'new-tag'], '1h');
       const wrapper = mount(
           <WorkLogInput workLog={initialWorkLog} tags={tags} presets={[]} onChange={noop} onSave={onSave}/>
       );
@@ -232,15 +233,15 @@ describe('WorkLogInput', () => {
 
       expect(onSave).toHaveBeenCalledWith({
         days: ['2019/03/01'],
-        expression: '1h #new-tag @2019/03/01',
-        tags: ['new-tag'],
+        expression: expression,
+        tags: ['projects', 'new-tag'],
         workload: '1h'
       });
       expect(wrapper.find(ConfirmNewTagsDialog).props().open).toBeFalsy();
     });
 
     it('closes dialog when CANCEL clicked', () => {
-      const initialWorkLog = new ParsedWorkLog('1h #new-tag @2019/03/01', ['2019/03/01'], ['new-tag'], '1h');
+      const initialWorkLog = new ParsedWorkLog('1h #projects #new-tag @2019/03/01', ['2019/03/01'], ['projects', 'new-tag'], '1h');
       const wrapper = mount(
           <WorkLogInput workLog={initialWorkLog} tags={tags} presets={[]} onChange={noop} onSave={noop}/>
       );
@@ -272,7 +273,7 @@ describe('WorkLogInput', () => {
     });
 
     it('shows success icon for valid expression', () => {
-      const initialWorkLog = new ParsedWorkLog('1h #new-tag @2019/03/01', ['2019/03/01'], ['new-tag'], '1h');
+      const initialWorkLog = new ParsedWorkLog('1h #projects #new-tag @2019/03/01', ['2019/03/01'], ['projects', 'new-tag'], '1h');
       const wrapper = mount(
           <WorkLogInput workLog={initialWorkLog} tags={tags} presets={[]} onChange={noop} onSave={noop}/>
       );

--- a/src/components/registrationPage/workLogInput/WorkLogInput.spec.tsx
+++ b/src/components/registrationPage/workLogInput/WorkLogInput.spec.tsx
@@ -3,7 +3,7 @@ import moment from 'moment';
 import { mount, ReactWrapper } from 'enzyme';
 import { InputBase } from '@material-ui/core';
 import { noop } from 'lodash';
-import { WorkLogInput } from './WorkLogInput';
+import {WorkLogInput, WorkLogInputProps} from './WorkLogInput';
 import { ParsedWorkLog } from '../../../workLogExpressionParser/ParsedWorkLog';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogActions from '@material-ui/core/DialogActions';
@@ -23,9 +23,7 @@ describe('WorkLogInput', () => {
   it('parses new work log expression', () => {
     const onChange = jest.fn();
     const initialWorkLog = ParsedWorkLog.empty();
-    const wrapper = mount(
-        <WorkLogInput workLog={initialWorkLog} tags={tags} presets={[]} onChange={onChange} onSave={noop}/>
-    );
+    const wrapper = mount(prepareWorLogInput({workLog: initialWorkLog, tags, onChange}));
 
     type(wrapper, '1d #projects #nvm @2019/03/01');
 
@@ -40,10 +38,7 @@ describe('WorkLogInput', () => {
   it('emits valid work log for today if date not present', () => {
     let parsedWorkLog: ParsedWorkLog = undefined;
     const initialWorkLog = ParsedWorkLog.empty();
-    const wrapper = mount(
-        <WorkLogInput workLog={initialWorkLog} tags={tags} presets={[]}
-                      onChange={parsed => parsedWorkLog = parsed} onSave={noop}/>
-    );
+    const wrapper = mount(prepareWorLogInput({workLog: initialWorkLog, tags, onChange: parsed => parsedWorkLog = parsed}));
 
     type(wrapper, '1d #projects #nvm');
 
@@ -57,10 +52,7 @@ describe('WorkLogInput', () => {
   it('emits invalid work log if tags not present', () => {
     let parsedWorkLog: ParsedWorkLog = undefined;
     const initialWorkLog = ParsedWorkLog.empty();
-    const wrapper = mount(
-        <WorkLogInput workLog={initialWorkLog} tags={tags} presets={[]}
-                      onChange={parsed => parsedWorkLog = parsed} onSave={noop}/>
-    );
+    const wrapper = mount(prepareWorLogInput({workLog: initialWorkLog, tags, onChange: parsed => parsedWorkLog = parsed}));
 
     type(wrapper, '1d');
 
@@ -71,10 +63,7 @@ describe('WorkLogInput', () => {
   it('emits save on enter click if valid work log', () => {
     let savePayload: ParsedWorkLog = undefined;
     const initialWorkLog = new ParsedWorkLog('1d #projects #nvm @2019/03/01', ['2019/03/01'], ['projects', 'nvm'], '1d');
-    const wrapper = mount(
-        <WorkLogInput workLog={initialWorkLog} tags={tags} presets={[]}
-                      onChange={noop} onSave={payload => savePayload = payload}/>
-    );
+    const wrapper = mount(prepareWorLogInput({workLog: initialWorkLog, tags, onSave: payload => savePayload = payload}));
 
     pressEnter(wrapper);
 
@@ -87,10 +76,7 @@ describe('WorkLogInput', () => {
   it('does not emit save on enter if invalid work log', () => {
     const onSave = jest.fn();
     const initialWorkLog = new ParsedWorkLog('1d', [], [], undefined);
-    const wrapper = mount(
-        <WorkLogInput workLog={initialWorkLog} tags={tags} presets={[]} onChange={noop} onSave={onSave}/>
-    );
-
+    const wrapper = mount(prepareWorLogInput({workLog: initialWorkLog, tags, onSave}));
     pressEnter(wrapper);
 
     expect(onSave).not.toHaveBeenCalled();
@@ -99,9 +85,7 @@ describe('WorkLogInput', () => {
   describe('suggestions', () => {
     it('does not show suggestion if word does not starts with # or @', () => {
       const initialWorkLog = ParsedWorkLog.empty();
-      const wrapper = mount(
-          <WorkLogInput workLog={initialWorkLog} tags={tags} presets={[]} onChange={noop} onSave={noop}/>
-      );
+      const wrapper = mount(prepareWorLogInput({workLog: initialWorkLog, tags}));
 
       typeAndFocus(wrapper, 'pro');
 
@@ -110,9 +94,7 @@ describe('WorkLogInput', () => {
 
     it('shows presets at the top when user typed #', () => {
       const initialWorkLog = ParsedWorkLog.empty();
-      const wrapper = mount(
-          <WorkLogInput workLog={initialWorkLog} tags={tags} presets={presets} onChange={noop} onSave={noop}/>
-      );
+      const wrapper = mount(prepareWorLogInput({workLog: initialWorkLog, tags, presets}));
 
       typeAndFocus(wrapper, '1d #');
 
@@ -123,9 +105,7 @@ describe('WorkLogInput', () => {
 
     it('shows suggestions when user starts typing tag name', () => {
       const initialWorkLog = ParsedWorkLog.empty();
-      const wrapper = mount(
-          <WorkLogInput workLog={initialWorkLog} tags={tags} presets={presets} onChange={noop} onSave={noop}/>
-      );
+      const wrapper = mount(prepareWorLogInput({workLog: initialWorkLog, tags, presets}));
 
       typeAndFocus(wrapper, '1d #pro');
 
@@ -137,10 +117,7 @@ describe('WorkLogInput', () => {
     it('replaces last word with selected tag suggestion', () => {
       let parsedWorkLog: ParsedWorkLog = undefined;
       const initialWorkLog = ParsedWorkLog.empty();
-      const wrapper = mount(
-          <WorkLogInput workLog={initialWorkLog} tags={tags} presets={[]}
-                        onChange={workLog => parsedWorkLog = workLog} onSave={noop}/>
-      );
+      const wrapper = mount(prepareWorLogInput({workLog: initialWorkLog, tags, onChange: workLog => parsedWorkLog = workLog}));
 
       typeAndFocus(wrapper, '1d #pro');
       chooseSuggestion(wrapper, 0);
@@ -151,10 +128,7 @@ describe('WorkLogInput', () => {
     it('replaces last word with selected preset', () => {
       let parsedWorkLog: ParsedWorkLog = undefined;
       const initialWorkLog = ParsedWorkLog.empty();
-      const wrapper = mount(
-          <WorkLogInput workLog={initialWorkLog} tags={tags} presets={presets}
-                        onChange={workLog => parsedWorkLog = workLog} onSave={noop}/>
-      );
+      const wrapper = mount(prepareWorLogInput({workLog: initialWorkLog, tags, presets, onChange: workLog => parsedWorkLog = workLog}));
 
       typeAndFocus(wrapper, '1d #pro');
       chooseSuggestion(wrapper, 0);
@@ -164,9 +138,7 @@ describe('WorkLogInput', () => {
 
     it('shows suggestions when user starts typing date', () => {
       const initialWorkLog = ParsedWorkLog.empty();
-      const wrapper = mount(
-          <WorkLogInput workLog={initialWorkLog} tags={tags} presets={[]} onChange={noop} onSave={noop}/>
-      );
+      const wrapper = mount(prepareWorLogInput({workLog: initialWorkLog, tags}));
 
       typeAndFocus(wrapper, '1d @to');
 
@@ -178,10 +150,7 @@ describe('WorkLogInput', () => {
     it('replaces last word with selected day suggestion', () => {
       let parsedWorkLog: ParsedWorkLog = undefined;
       const initialWorkLog = ParsedWorkLog.empty();
-      const wrapper = mount(
-          <WorkLogInput workLog={initialWorkLog} tags={tags} presets={[]}
-                        onChange={workLog => parsedWorkLog = workLog} onSave={noop}/>
-      );
+      const wrapper = mount(prepareWorLogInput({workLog: initialWorkLog, tags, onChange: workLog => parsedWorkLog = workLog}));
 
       typeAndFocus(wrapper, '1d #projects @to');
       chooseSuggestion(wrapper, 1);
@@ -209,9 +178,7 @@ describe('WorkLogInput', () => {
     it('shows confirmation dialog if work log contains new tags', () => {
       const onSave = jest.fn();
       const initialWorkLog = new ParsedWorkLog('1h #projects #new-tag @2019/03/01', ['2019/03/01'], ['projects', 'new-tag'], '1h');
-      const wrapper = mount(
-          <WorkLogInput workLog={initialWorkLog} tags={tags} presets={[]} onChange={noop} onSave={onSave}/>
-      );
+      const wrapper = mount(prepareWorLogInput({workLog: initialWorkLog, tags}));
 
       pressEnter(wrapper);
 
@@ -224,9 +191,7 @@ describe('WorkLogInput', () => {
       const onSave = jest.fn();
       const expression = '1h #projects #new-tag @2019/03/01';
       const initialWorkLog = new ParsedWorkLog(expression, ['2019/03/01'], ['projects', 'new-tag'], '1h');
-      const wrapper = mount(
-          <WorkLogInput workLog={initialWorkLog} tags={tags} presets={[]} onChange={noop} onSave={onSave}/>
-      );
+      const wrapper = mount(prepareWorLogInput({workLog: initialWorkLog, tags, onSave}));
 
       pressEnter(wrapper);
       confirmButton(wrapper).simulate('click');
@@ -242,9 +207,7 @@ describe('WorkLogInput', () => {
 
     it('closes dialog when CANCEL clicked', () => {
       const initialWorkLog = new ParsedWorkLog('1h #projects #new-tag @2019/03/01', ['2019/03/01'], ['projects', 'new-tag'], '1h');
-      const wrapper = mount(
-          <WorkLogInput workLog={initialWorkLog} tags={tags} presets={[]} onChange={noop} onSave={noop}/>
-      );
+      const wrapper = mount(prepareWorLogInput({workLog: initialWorkLog, tags}));
 
       pressEnter(wrapper);
       cancelButton(wrapper).simulate('click');
@@ -264,9 +227,7 @@ describe('WorkLogInput', () => {
   describe('validation', () => {
     it('does not show icon for empty input', () => {
       const initialWorkLog = ParsedWorkLog.empty();
-      const wrapper = mount(
-          <WorkLogInput workLog={initialWorkLog} tags={tags} presets={[]} onChange={noop} onSave={noop}/>
-      );
+      const wrapper = mount(prepareWorLogInput({workLog: initialWorkLog, tags}));
 
       expect(wrapper.find('[data-error-indicator]')).toHaveLength(0);
       expect(wrapper.find('[data-ok-indicator]')).toHaveLength(0);
@@ -274,9 +235,7 @@ describe('WorkLogInput', () => {
 
     it('shows success icon for valid expression', () => {
       const initialWorkLog = new ParsedWorkLog('1h #projects #new-tag @2019/03/01', ['2019/03/01'], ['projects', 'new-tag'], '1h');
-      const wrapper = mount(
-          <WorkLogInput workLog={initialWorkLog} tags={tags} presets={[]} onChange={noop} onSave={noop}/>
-      );
+      const wrapper = mount(prepareWorLogInput({workLog: initialWorkLog, tags}));
 
       expect(wrapper.find('[data-error-indicator]')).toHaveLength(0);
       expect(wrapper.find('[data-ok-indicator]').length).toBeGreaterThan(0);
@@ -284,15 +243,40 @@ describe('WorkLogInput', () => {
 
     it('shows error icon for invalid expression', () => {
       const initialWorkLog = new ParsedWorkLog('1hasd', [], [], '');
-      const wrapper = mount(
-          <WorkLogInput workLog={initialWorkLog} tags={tags} presets={[]} onChange={noop} onSave={noop}/>
-      );
+      const wrapper = mount(prepareWorLogInput({workLog: initialWorkLog, tags}));
 
       expect(wrapper.find('[data-error-indicator]').length).toBeGreaterThan(0);
       expect(wrapper.find('[data-ok-indicator]')).toHaveLength(0);
     });
   });
+  
+  describe('auto added tags', () => {
+    it('adds tags as per config', () => {
+      let parsedWorkLog: ParsedWorkLog;
+      const autoAddedTagsMapping = new Map().set('tag-with-auto-added', ['added-tag']);
+      const wrapper = mount(prepareWorLogInput({tags: [], onChange: e => parsedWorkLog = e, autoAddedTagsMapping}));
 
+      type(wrapper, "#tag-with-auto-added");
+
+      expect(parsedWorkLog.tags).toContain('added-tag');
+      expect(parsedWorkLog.tags).toContain('tag-with-auto-added');
+      expect(parsedWorkLog.tags.length).toEqual(2);
+    })
+  });
+
+  function prepareWorLogInput(overrides: Partial<WorkLogInputProps>) {
+    const props: WorkLogInputProps = {
+      workLog: overrides.workLog || ParsedWorkLog.empty(),
+      tags: overrides.tags || [],
+      presets: overrides.presets || [],
+      onChange: overrides.onChange || noop,
+      onSave: overrides.onSave || noop,
+      autoAddedTagsMapping: overrides.autoAddedTagsMapping || new Map<string, string[]>()
+    };
+
+    return <WorkLogInput {...props} />;
+  }
+  
   function type(wrapper, expression: string) {
     const input = workLogInput(wrapper);
     input.simulate('change', {target: {value: expression}});

--- a/src/components/registrationPage/workLogInput/WorkLogInput.tsx
+++ b/src/components/registrationPage/workLogInput/WorkLogInput.tsx
@@ -103,7 +103,7 @@ export class WorkLogInput extends Component<WorkLogInputProps, WorkLogInputState
   private handleSubmit = (event: React.KeyboardEvent) => {
     if (event.key === 'Enter') {
       const {onSave, workLog, tags} = this.props;
-      if (workLog.valid) {
+      if (workLog.validate().valid) {
         const newTags = difference(workLog.tags, tags);
         if (isEmpty(newTags)) {
           onSave(workLog);

--- a/src/components/registrationPage/workLogInput/WorkLogInput.tsx
+++ b/src/components/registrationPage/workLogInput/WorkLogInput.tsx
@@ -1,27 +1,28 @@
-import React, { Component } from 'react';
-import { Paper } from '@material-ui/core';
+import React, {Component} from 'react';
+import {Paper} from '@material-ui/core';
 import InputBase from '@material-ui/core/InputBase';
 import IconButton from '@material-ui/core/IconButton';
 import HelpIcon from '@material-ui/icons/Help';
 import './WorkLogInput.scss'
-import { WorkLogHelpDialog } from "../workLogHelpDialog/WorkLogHelpDialog";
-import { WorkLogExpressionParser } from '../../../workLogExpressionParser/WorkLogExpressionParser';
+import {WorkLogHelpDialog} from "../workLogHelpDialog/WorkLogHelpDialog";
+import {WorkLogExpressionParser} from '../../../workLogExpressionParser/WorkLogExpressionParser';
 import Autosuggest from 'react-autosuggest';
-import { Suggestion, SuggestionItem } from '../../Suggestion';
-import { isEmpty, noop, difference } from 'lodash';
-import { TagsSuggestionFactory } from './TagsSuggestionFactory';
-import { DatesSuggestionFactory } from './DatesSuggestionFactory';
-import { ConfirmNewTagsDialog } from '../confirmNewTagsDialog/ConfirmNewTagsDialog';
-import { ParsedWorkLog } from '../../../workLogExpressionParser/ParsedWorkLog';
-import { ValidationStatus } from './ValidationStatus';
-import { Preset } from '../registration.model';
+import {Suggestion, SuggestionItem} from '../../Suggestion';
+import {difference, flatMap, isEmpty, noop} from 'lodash';
+import {TagsSuggestionFactory} from './TagsSuggestionFactory';
+import {DatesSuggestionFactory} from './DatesSuggestionFactory';
+import {ConfirmNewTagsDialog} from '../confirmNewTagsDialog/ConfirmNewTagsDialog';
+import {ParsedWorkLog} from '../../../workLogExpressionParser/ParsedWorkLog';
+import {ValidationStatus} from './ValidationStatus';
+import {Preset} from '../registration.model';
 
-interface WorkLogInputProps {
+export interface WorkLogInputProps {
   workLog: ParsedWorkLog;
   tags: string[];
   presets: Preset[];
   onChange: (workLog: ParsedWorkLog) => void;
   onSave: (workLog: ParsedWorkLog) => void;
+  autoAddedTagsMapping: Map<string, string[]>;
 }
 
 interface WorkLogInputState {
@@ -95,9 +96,13 @@ export class WorkLogInput extends Component<WorkLogInputProps, WorkLogInputState
   );
 
   private handleInputChange = (event, {newValue}) => {
-    const {onChange} = this.props;
+    const {onChange, autoAddedTagsMapping} = this.props;
     const workLog = this.workLogExpressionParser.parse(newValue);
-    onChange(workLog)
+
+    const tagsWithAutoAddMapping = workLog.tags.filter(tag => autoAddedTagsMapping.has(tag));
+    const autoAddedTags = flatMap(tagsWithAutoAddMapping, tag => autoAddedTagsMapping.get(tag));
+
+    onChange(workLog.withAddedTags(autoAddedTags));
   };
 
   private handleSubmit = (event: React.KeyboardEvent) => {

--- a/src/redux/registration.actions.ts
+++ b/src/redux/registration.actions.ts
@@ -44,7 +44,7 @@ const workLogChangedAction = (workLog: ParsedWorkLog) => ({
     tags: workLog.tags,
     workload: workLog.workload,
     expression: workLog.expression,
-    valid: workLog.valid
+    valid: workLog.validate().valid
   }
 });
 

--- a/src/tagsConfig.json
+++ b/src/tagsConfig.json
@@ -1,0 +1,35 @@
+{
+  "topLevel": [
+    "projects",
+    "internal",
+    "sick",
+    "vacation",
+    "vacation-special",
+    "holiday"
+  ],
+  "autoSubTags": {
+    "internal": [
+      "brown-bag",
+      "blog",
+      "recruitment",
+      "standup",
+      "rada",
+      "self-dev",
+      "sales",
+      "onboarding",
+      "project-estimation",
+      "meetings",
+      "gdansk",
+      "conference",
+      "preparation",
+      "workshop",
+      "office",
+      "www",
+      "ux-process",
+      "cx"
+    ]
+  },
+  "requireAdditionalTag": [
+    "projects"
+  ]
+}

--- a/src/utils/collectionUtils.spec.ts
+++ b/src/utils/collectionUtils.spec.ts
@@ -1,0 +1,46 @@
+import {toReversedMap} from "./collectionUtils";
+
+describe('mapping reversal', () => {
+    it('should reverse mapping', () => {
+        const mappingObject = {
+            key1: ['val1', 'val2'],
+            key2: ['val2', 'val3']
+        };
+
+        const result = toReversedMap(mappingObject);
+
+        expect(result.get('val1')).toEqual(['key1']);
+        expect(result.get('val2')).toEqual(['key1','key2']);
+        expect(result.get('val3')).toEqual(['key2']);
+    });
+
+    it('should deal with empty values', () => {
+        const mappingObject = {
+            key: []
+        };
+
+        const result = toReversedMap(mappingObject);
+
+        expect(result.size).toEqual(0);
+    });
+
+    it('should deal with empty mapping object', () => {
+        const mappingObject = {};
+
+        const result = toReversedMap(mappingObject);
+
+        expect(result.size).toEqual(0);
+    });
+
+
+    it('should deal with non-truthy values', () => {
+        const mappingObject = {
+            key1: null,
+            key2: undefined
+        };
+
+        const result = toReversedMap(mappingObject);
+
+        expect(result.size).toEqual(0);
+    });
+});

--- a/src/utils/collectionUtils.ts
+++ b/src/utils/collectionUtils.ts
@@ -1,0 +1,12 @@
+import {forEach, union} from "lodash";
+
+export function toReversedMap<T extends any>(mappingObject: {[key: string] : T[]}): Map<T, string[]> {
+    const reversedMapping: Map<T, string[]> = new Map();
+    forEach(mappingObject, (value, key) => {
+        value && value.forEach(v => {
+            reversedMapping.set(v, union(reversedMapping.get(v), [key]))
+        })
+    });
+
+    return reversedMapping;
+}

--- a/src/utils/tagUtils.ts
+++ b/src/utils/tagUtils.ts
@@ -1,0 +1,6 @@
+import * as tagsConfig from "../tagsConfig.json";
+import {toReversedMap} from "./collectionUtils";
+
+export function extractAutoAddedTagsMapping(): Map<string, string[]> {
+    return toReversedMap(tagsConfig.autoSubTags);
+}

--- a/src/workLogExpressionParser/ParsedWorkLog.spec.ts
+++ b/src/workLogExpressionParser/ParsedWorkLog.spec.ts
@@ -50,26 +50,46 @@ describe('ParsedWorkLog', () => {
   describe('validation', () => {
 
     it('should be invalid when neither #project or #internal tag present', function () {
-      const workLog = new ParsedWorkLog('@2019/03/01~@2019/03/02', ['2019/03/01', '2019/03/02'], ['sealights'], undefined);
+      const workLog = new ParsedWorkLog('@2019/03/01~@2019/03/02', ['2019/03/01', '2019/03/02'], ['sealights'], '1d');
 
       expect(workLog.validate().valid).toBeFalsy();
-      expect(workLog.validate().errors).toContain('tags must include either #internal or #projects');
+      expect(workLog.validate().errors).toEqual(['tags must include either #internal or #projects']);
     });
 
     it('should be invalid when both #project and #internal tag present', function () {
-      const workLog = new ParsedWorkLog('@2019/03/01~@2019/03/02', ['2019/03/01', '2019/03/02'], ['projects', 'internal'], undefined);
+      const workLog = new ParsedWorkLog('@2019/03/01~@2019/03/02', ['2019/03/01', '2019/03/02'], ['projects', 'internal'], '1d');
 
       expect(workLog.validate().valid).toBeFalsy();
-      expect(workLog.validate().errors).toContain('#internal and #projects tags cannot be used together');
+      expect(workLog.validate().errors).toEqual(['#internal and #projects tags cannot be used together']);
     });
 
     it('should be invalid when no workload', function () {
       const workLog = new ParsedWorkLog('@2019/03/01~@2019/03/02', ['2019/03/01', '2019/03/02'], ['projects', 'sealights'], undefined);
 
       expect(workLog.validate().valid).toBeFalsy();
-      expect(workLog.validate().errors).toContain('workload was not provided');
+      expect(workLog.validate().errors).toEqual(['workload was not provided']);
     });
 
+    it('should be invalid if #projects is the only tag', function () {
+      const workLog = new ParsedWorkLog('@2019/03/01~@2019/03/02', ['2019/03/01', '2019/03/02'], ['projects'], '1d');
+
+      expect(workLog.validate().valid).toBeFalsy();
+      expect(workLog.validate().errors).toEqual(['missing specific project tag: #projects #your-project-name']);
+    });
+
+    it('should be valid if #project and another tag present', function () {
+      const workLog = new ParsedWorkLog('@2019/03/01~@2019/03/02', ['2019/03/01', '2019/03/02'], ['projects', 'best-project-ever'], '1d');
+
+      expect(workLog.validate().valid).toBeTruthy();
+      expect(workLog.validate().errors).toEqual([]);
+    });
+
+    it('should be valid if #internal is the only tag', function () {
+      const workLog = new ParsedWorkLog('@2019/03/01~@2019/03/02', ['2019/03/01', '2019/03/02'], ['internal'], '1d');
+
+      expect(workLog.validate().valid).toBeTruthy();
+      expect(workLog.validate().errors).toEqual([]);
+    });
   });
 
 });

--- a/src/workLogExpressionParser/ParsedWorkLog.spec.ts
+++ b/src/workLogExpressionParser/ParsedWorkLog.spec.ts
@@ -46,4 +46,30 @@ describe('ParsedWorkLog', () => {
     expect(newWorkLog.expression).toEqual('@2019/03/11~@2019/03/13');
     expect(newWorkLog.days).toEqual(['2019/03/11', '2019/03/12', '2019/03/13']);
   });
+
+  describe('validation', () => {
+
+    it('should be invalid when neither #project or #internal tag present', function () {
+      const workLog = new ParsedWorkLog('@2019/03/01~@2019/03/02', ['2019/03/01', '2019/03/02'], ['sealights'], undefined);
+
+      expect(workLog.validate().valid).toBeFalsy();
+      expect(workLog.validate().errors).toContain('tags must include either #internal or #projects');
+    });
+
+    it('should be invalid when both #project and #internal tag present', function () {
+      const workLog = new ParsedWorkLog('@2019/03/01~@2019/03/02', ['2019/03/01', '2019/03/02'], ['projects', 'internal'], undefined);
+
+      expect(workLog.validate().valid).toBeFalsy();
+      expect(workLog.validate().errors).toContain('#internal and #projects tags cannot be used together');
+    });
+
+    it('should be invalid when no workload', function () {
+      const workLog = new ParsedWorkLog('@2019/03/01~@2019/03/02', ['2019/03/01', '2019/03/02'], ['projects', 'sealights'], undefined);
+
+      expect(workLog.validate().valid).toBeFalsy();
+      expect(workLog.validate().errors).toContain('workload was not provided');
+    });
+
+  });
+
 });

--- a/src/workLogExpressionParser/ParsedWorkLog.spec.ts
+++ b/src/workLogExpressionParser/ParsedWorkLog.spec.ts
@@ -1,4 +1,5 @@
 import { ParsedWorkLog } from './ParsedWorkLog';
+import * as tagsConfig from "../tagsConfig.json";
 
 describe('ParsedWorkLog', () => {
 
@@ -49,18 +50,18 @@ describe('ParsedWorkLog', () => {
 
   describe('validation', () => {
 
-    it('should be invalid when neither #project or #internal tag present', function () {
-      const workLog = new ParsedWorkLog('@2019/03/01~@2019/03/02', ['2019/03/01', '2019/03/02'], ['sealights'], '1d');
+    it('should be invalid when no top level tag present', function () {
+      const workLog = new ParsedWorkLog('@2019/03/01~@2019/03/02', ['2019/03/01', '2019/03/02'], ['not-top-level-tag'], '1d');
 
       expect(workLog.validate().valid).toBeFalsy();
-      expect(workLog.validate().errors).toEqual(['tags must include either #internal or #projects']);
+      expect(workLog.validate().errors).toEqual([ParsedWorkLog.EXACTLY_ONE_TOP_LEVEL_TAG_ALLOWED_MSG]);
     });
 
-    it('should be invalid when both #project and #internal tag present', function () {
-      const workLog = new ParsedWorkLog('@2019/03/01~@2019/03/02', ['2019/03/01', '2019/03/02'], ['projects', 'internal'], '1d');
+    it('should be invalid when two top level tags present', function () {
+      const workLog = new ParsedWorkLog('@2019/03/01~@2019/03/02', ['2019/03/01', '2019/03/02'], [tagsConfig.topLevel[0], tagsConfig.topLevel[1]], '1d');
 
       expect(workLog.validate().valid).toBeFalsy();
-      expect(workLog.validate().errors).toEqual(['#internal and #projects tags cannot be used together']);
+      expect(workLog.validate().errors).toEqual([ParsedWorkLog.EXACTLY_ONE_TOP_LEVEL_TAG_ALLOWED_MSG]);
     });
 
     it('should be invalid when no workload', function () {

--- a/src/workLogExpressionParser/ParsedWorkLog.ts
+++ b/src/workLogExpressionParser/ParsedWorkLog.ts
@@ -3,6 +3,7 @@ import { isEmpty, size } from 'lodash';
 export class ParsedWorkLog {
   static readonly DATE_RANGE_PATTERN = /@[A-Z0-9/a-z-+]+~@[A-Z0-9/a-z-+]+/g;
   static readonly DATE_PATTERN = /@[A-Z0-9/a-z-+]+/g;
+  static readonly PROJECTS_TAG = "projects";
 
   constructor(
       readonly expression: string,
@@ -12,8 +13,19 @@ export class ParsedWorkLog {
   ) {
   }
 
-  get valid(): boolean {
-    return !isEmpty(this.tags) && !isEmpty(this.workload);
+  public validate(): ValidationResult {
+    const errors = [];
+    if (!this.tags.includes("internal") && !this.tags.includes(ParsedWorkLog.PROJECTS_TAG)) {
+      errors.push('tags must include either #internal or #projects');
+    }
+    if (this.tags.includes("internal") && this.tags.includes(ParsedWorkLog.PROJECTS_TAG)) {
+      errors.push('#internal and #projects tags cannot be used together');
+    }
+    if (isEmpty(this.workload)) {
+      errors.push('workload was not provided');
+    }
+
+    return {valid: errors.length === 0, errors}
   }
 
   static empty(): ParsedWorkLog {
@@ -52,4 +64,9 @@ export class ParsedWorkLog {
     }
     return newDaysExpression;
   }
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  errors: string[];
 }

--- a/src/workLogExpressionParser/ParsedWorkLog.ts
+++ b/src/workLogExpressionParser/ParsedWorkLog.ts
@@ -4,6 +4,7 @@ export class ParsedWorkLog {
   static readonly DATE_RANGE_PATTERN = /@[A-Z0-9/a-z-+]+~@[A-Z0-9/a-z-+]+/g;
   static readonly DATE_PATTERN = /@[A-Z0-9/a-z-+]+/g;
   static readonly PROJECTS_TAG = "projects";
+  static readonly INTERNAL_TAG = "internal";
 
   constructor(
       readonly expression: string,
@@ -15,12 +16,16 @@ export class ParsedWorkLog {
 
   public validate(): ValidationResult {
     const errors = [];
-    if (!this.tags.includes("internal") && !this.tags.includes(ParsedWorkLog.PROJECTS_TAG)) {
+    if (!this.tags.includes(ParsedWorkLog.INTERNAL_TAG) && !this.tags.includes(ParsedWorkLog.PROJECTS_TAG)) {
       errors.push('tags must include either #internal or #projects');
     }
-    if (this.tags.includes("internal") && this.tags.includes(ParsedWorkLog.PROJECTS_TAG)) {
+    if (this.tags.includes(ParsedWorkLog.INTERNAL_TAG) && this.tags.includes(ParsedWorkLog.PROJECTS_TAG)) {
       errors.push('#internal and #projects tags cannot be used together');
     }
+    if (this.tags.includes(ParsedWorkLog.PROJECTS_TAG) && this.tags.length < 2) {
+      errors.push('missing specific project tag: #projects #your-project-name');
+    }
+
     if (isEmpty(this.workload)) {
       errors.push('workload was not provided');
     }

--- a/src/workLogExpressionParser/WorkLogExpressionParser.spec.ts
+++ b/src/workLogExpressionParser/WorkLogExpressionParser.spec.ts
@@ -1,6 +1,7 @@
 import { TimeProvider } from '../utils/dateTimeUtils';
 import { WorkLogExpressionParser } from './WorkLogExpressionParser';
 
+
 describe('WorkLogExpressionParser', () => {
   const CURRENT_DATE = "2014/01/02";
   const CURRENT_WEEKDAY = 'thursday';
@@ -13,6 +14,7 @@ describe('WorkLogExpressionParser', () => {
   const WEEK_AFTER_TODAY = '2014/01/09';
   const SOME_WORKLOAD = '1d 1h 1m';
   const SOME_PROJECT = 'ProjectManhattan';
+  const PROJECTS_TAG = 'projects';
   const SOME_DATE = '2013/02/01';
   let workLogExpressionParser: WorkLogExpressionParser;
   let timeProvider;
@@ -24,131 +26,131 @@ describe('WorkLogExpressionParser', () => {
   });
 
   it('parses full worklog', () => {
-    const workLogExpression = '2h #ProjectManhattan @2014/01/03';
+    const workLogExpression = '2h #projects #ProjectManhattan @2014/01/03';
 
     expect(workLogExpressionParser.isValid(workLogExpression)).toBeTruthy();
     expect(workLogExpressionParser.parse(workLogExpression)).toEqual({
-      expression: '2h #ProjectManhattan @2014/01/03',
-      tags: ['ProjectManhattan'],
+      expression: '2h #projects #ProjectManhattan @2014/01/03',
+      tags: [PROJECTS_TAG, 'ProjectManhattan'],
       workload: '2h',
       days: ['2014/01/03']
     });
   });
 
   it('parses work log for current day', () => {
-    const workLogExpression = '2h #ProjectManhattan';
+    const workLogExpression = '2h #projects #ProjectManhattan';
 
     expect(workLogExpressionParser.isValid(workLogExpression)).toBeTruthy();
     expect(workLogExpressionParser.parse(workLogExpression).days).toEqual([CURRENT_DATE]);
   });
 
   it('parses work log for monday', () => {
-    const workLogExpression = '2h #ProjectManhattan @monday';
+    const workLogExpression = '2h #projects #ProjectManhattan @monday';
 
     expect(workLogExpressionParser.isValid(workLogExpression)).toBeTruthy();
     expect(workLogExpressionParser.parse(workLogExpression).days).toEqual([MONDAY_BEFORE_TODAY]);
   });
 
   it('parses work log for weekday with upper letter', () => {
-    const workLogExpression = '2h #ProjectManhattan @Monday';
+    const workLogExpression = '2h #projects #ProjectManhattan @Monday';
 
     expect(workLogExpressionParser.isValid(workLogExpression)).toBeTruthy();
     expect(workLogExpressionParser.parse(workLogExpression).days).toEqual([MONDAY_BEFORE_TODAY]);
   });
 
   it('parses work log for friday', () => {
-    const workLogExpression = '2h #ProjectManhattan @friday';
+    const workLogExpression = '2h #projects #ProjectManhattan @friday';
 
     expect(workLogExpressionParser.isValid(workLogExpression)).toBeTruthy();
     expect(workLogExpressionParser.parse(workLogExpression).days).toEqual([FRIDAY_BEFORE_TODAY]);
   });
 
   it('parses work log for last monday', () => {
-    const workLogExpression = '2h #ProjectManhattan @last-monday';
+    const workLogExpression = '2h #projects #ProjectManhattan @last-monday';
 
     expect(workLogExpressionParser.isValid(workLogExpression)).toBeTruthy();
     expect(workLogExpressionParser.parse(workLogExpression).days).toEqual([MONDAY_BEFORE_TODAY]);
   });
 
   it('parses work log for next monday', () => {
-    const workLogExpression = '2h #ProjectManhattan @next-monday';
+    const workLogExpression = '2h #projects #ProjectManhattan @next-monday';
 
     expect(workLogExpressionParser.isValid(workLogExpression)).toBeTruthy();
     expect(workLogExpressionParser.parse(workLogExpression).days).toEqual([MONDAY_AFTER_TODAY]);
   });
 
   it('parses work log for weekday exactly week before today', () => {
-    const workLogExpression = '2h #ProjectManhattan @last-thursday';
+    const workLogExpression = '2h #projects #ProjectManhattan @last-thursday';
 
     expect(workLogExpressionParser.isValid(workLogExpression)).toBeTruthy();
     expect(workLogExpressionParser.parse(workLogExpression).days).toEqual([WEEK_BEFORE_TODAY]);
   });
 
   it('parses work log for weekday exactly week after today', () => {
-    const workLogExpression = '2h #ProjectManhattan @next-thursday';
+    const workLogExpression = '2h #projects #ProjectManhattan @next-thursday';
 
     expect(workLogExpressionParser.isValid(workLogExpression)).toBeTruthy();
     expect(workLogExpressionParser.parse(workLogExpression).days).toEqual([WEEK_AFTER_TODAY]);
   });
 
   it('parses work log for yesterday', () => {
-    const workLogExpression = '2h #ProjectManhattan @yesterday';
+    const workLogExpression = '2h #projects #ProjectManhattan @yesterday';
 
     expect(workLogExpressionParser.isValid(workLogExpression)).toBeTruthy();
     expect(workLogExpressionParser.parse(workLogExpression).days).toEqual([YESTERDAY]);
   });
 
   it('parses work log for today', () => {
-    const workLogExpression = '2h #ProjectManhattan @today';
+    const workLogExpression = '2h #projects #ProjectManhattan @today';
 
     expect(workLogExpressionParser.isValid(workLogExpression)).toBeTruthy();
     expect(workLogExpressionParser.parse(workLogExpression).days).toEqual([CURRENT_DATE]);
   });
 
   it('parses work log for today if given weekday', () => {
-    const workLogExpression = '2h #ProjectManhattan @' + CURRENT_WEEKDAY;
+    const workLogExpression = '2h #projects #ProjectManhattan @' + CURRENT_WEEKDAY;
 
     expect(workLogExpressionParser.isValid(workLogExpression)).toBeTruthy();
     expect(workLogExpressionParser.parse(workLogExpression).days).toEqual([CURRENT_DATE]);
   });
 
   it('parses work log for tomorrow', () => {
-    const workLogExpression = '2h #ProjectManhattan @tomorrow';
+    const workLogExpression = '2h #projects #ProjectManhattan @tomorrow';
 
     expect(workLogExpressionParser.isValid(workLogExpression)).toBeTruthy();
     expect(workLogExpressionParser.parse(workLogExpression).days).toEqual([TOMORROW]);
   });
 
   it('parses work log for yesterday by t-1', () => {
-    const workLogExpression = '2h #ProjectManhattan @t-1';
+    const workLogExpression = '2h #projects #ProjectManhattan @t-1';
 
     expect(workLogExpressionParser.isValid(workLogExpression)).toBeTruthy();
     expect(workLogExpressionParser.parse(workLogExpression).days).toEqual([YESTERDAY]);
   });
 
   it('parses work log for tomorrow by t+1', () => {
-    const workLogExpression = '2h #ProjectManhattan @t+1';
+    const workLogExpression = '2h #projects #ProjectManhattan @t+1';
 
     expect(workLogExpressionParser.isValid(workLogExpression)).toBeTruthy();
     expect(workLogExpressionParser.parse(workLogExpression).days).toEqual([TOMORROW]);
   });
 
   it('parses work log with days and hours', () => {
-    const workLogExpression = '1d 3h #ProjectManhattan';
+    const workLogExpression = '1d 3h #projects #ProjectManhattan';
 
     expect(workLogExpressionParser.isValid(workLogExpression)).toBeTruthy();
     expect(workLogExpressionParser.parse(workLogExpression).workload).toEqual("1d 3h");
   });
 
   it('parses work log with days and hours', () => {
-    const workLogExpression = '1d 5h 15m #ProjectManhattan';
+    const workLogExpression = '1d 5h 15m #projects #ProjectManhattan';
 
     expect(workLogExpressionParser.isValid(workLogExpression)).toBeTruthy();
     expect(workLogExpressionParser.parse(workLogExpression).workload).toEqual("1d 5h 15m");
   });
 
   it('parses work log for 1d by default', () => {
-    const workLogExpression = '#ProjectManhattan';
+    const workLogExpression = '#projects #ProjectManhattan';
 
     expect(workLogExpressionParser.isValid(workLogExpression)).toBeTruthy();
     expect(workLogExpressionParser.parse(workLogExpression).workload).toEqual("1d");
@@ -179,68 +181,68 @@ describe('WorkLogExpressionParser', () => {
   });
 
   it('does not parse workload at the end of project name', () => {
-    const workLogExpression = '#project2d';
+    const workLogExpression = '#projects #project2d';
 
     expect(workLogExpressionParser.isValid(workLogExpression)).toBeTruthy();
     expect(workLogExpressionParser.parse(workLogExpression).workload).toEqual("1d");
-    expect(workLogExpressionParser.parse(workLogExpression).tags).toEqual(["project2d"]);
+    expect(workLogExpressionParser.parse(workLogExpression).tags).toEqual([PROJECTS_TAG,"project2d"]);
   });
 
   it('parses work log with hyphen in project for today', () => {
-    const workLogExpression = '2h #Project-Manhattan';
+    const workLogExpression = '2h #projects #Project-Manhattan';
 
     expect(workLogExpressionParser.isValid(workLogExpression)).toBeTruthy();
-    expect(workLogExpressionParser.parse(workLogExpression).tags).toEqual(["Project-Manhattan"]);
+    expect(workLogExpressionParser.parse(workLogExpression).tags).toEqual([PROJECTS_TAG, "Project-Manhattan"]);
   });
 
   it('does not parse work log with double day info', () => {
-    const workLogExpression = '#Project-Manhattan @monday @tuesday';
+    const workLogExpression = '#Project-Manhattan #projects @monday @tuesday';
 
     expect(workLogExpressionParser.isValid(workLogExpression)).toBeFalsy();
     const parsed = workLogExpressionParser.parse(workLogExpression);
-    expect(parsed.valid).toBeFalsy();
+    expect(parsed.validate().valid).toBeFalsy();
   });
 
   it('does not parse work log with double workload hours info', () => {
-    const workLogExpression = '2h 3h #Project-Manhattan';
+    const workLogExpression = '2h 3h #projects #Project-Manhattan';
 
     expect(workLogExpressionParser.isValid(workLogExpression)).toBeFalsy();
     const parsed = workLogExpressionParser.parse(workLogExpression);
-    expect(parsed.valid).toBeFalsy();
+    expect(parsed.validate().valid).toBeFalsy();
   });
 
   it('does not parse work log with double workload days info', () => {
-    const workLogExpression = '1d 1d #Project-Manhattan';
+    const workLogExpression = '1d 1d #projects #Project-Manhattan';
 
     expect(workLogExpressionParser.isValid(workLogExpression)).toBeFalsy();
     const parsed = workLogExpressionParser.parse(workLogExpression);
-    expect(parsed.valid).toBeFalsy();
+    expect(parsed.validate().valid).toBeFalsy();
   });
 
   it('does not parse work log with double workload minutes info', () => {
-    const workLogExpression = '30m 45m #Project-Manhattan';
+    const workLogExpression = '30m 45m #projects #Project-Manhattan';
 
     expect(workLogExpressionParser.isValid(workLogExpression)).toBeFalsy();
     const parsed = workLogExpressionParser.parse(workLogExpression);
-    expect(parsed.valid).toBeFalsy();
+    expect(parsed.validate().valid).toBeFalsy();
   });
 
   it('does not parse entry with invalid number', () => {
-    const workLogExpression = '1h #Project-Manhattan 2h 3h @t-123456789';
+    const workLogExpression = '1h #projects #Project-Manhattan 2h 3h @t-123456789';
 
     expect(workLogExpressionParser.isValid(workLogExpression)).toBeFalsy();
     const parsed = workLogExpressionParser.parse(workLogExpression);
-    expect(parsed.valid).toBeFalsy();
+    expect(parsed.validate().valid).toBeFalsy();
   });
 
   it('does not parse entry with negative workload', () => {
-    const workLogExpression = '-10h #Project-Manhattan';
+    const workLogExpression = '-10h #projects #Project-Manhattan';
 
     expect(workLogExpressionParser.isValid(workLogExpression)).toBeFalsy();
     const parsed = workLogExpressionParser.parse(workLogExpression);
-    expect(parsed.valid).toBeFalsy();
+    expect(parsed.validate().valid).toBeFalsy();
     expect(parsed).toEqual({
-      expression: '-10h #Project-Manhattan',
+      expression: workLogExpression,
       days: [],
       tags: [],
       workload: undefined
@@ -248,33 +250,33 @@ describe('WorkLogExpressionParser', () => {
   });
 
   it('parses entry for date without trailing zeros', () => {
-    const workLogExpression = '4h 30m #Project-Manhattan @2014/1/1';
+    const workLogExpression = '4h 30m #projects #Project-Manhattan @2014/1/1';
 
     expect(workLogExpressionParser.isValid(workLogExpression)).toBeTruthy();
     expect(workLogExpressionParser.parse(workLogExpression).days).toEqual([YESTERDAY]);
   });
 
   it('parses work log padded with spaces', () => {
-    const workLogExpression = '  2h #ProjectManhattan @2014/01/03   ';
+    const workLogExpression = '  2h #ProjectManhattan #projects @2014/01/03   ';
 
     expect(workLogExpressionParser.isValid(workLogExpression)).toBeTruthy();
 
     const parsed = workLogExpressionParser.parse(workLogExpression);
-    expect(parsed.valid).toBeTruthy();
+    expect(parsed.validate().valid).toBeTruthy();
     expect(parsed).toEqual({
-      expression: '  2h #ProjectManhattan @2014/01/03   ',
-      tags: ['ProjectManhattan'],
+      expression: workLogExpression,
+      tags: ['ProjectManhattan', PROJECTS_TAG],
       workload: '2h',
       days: ['2014/01/03']
     });
   });
 
   it('parses multiple projects', () => {
-    const workLogExpression = '4h #ProjectManhattan #Apollo @today';
+    const workLogExpression = '4h #ProjectManhattan #Apollo #projects @today';
 
     expect(workLogExpressionParser.isValid(workLogExpression)).toBeTruthy();
     expect(workLogExpressionParser.parse(workLogExpression).tags).toEqual([
-      'ProjectManhattan', 'Apollo'
+      'ProjectManhattan', 'Apollo', PROJECTS_TAG
     ]);
   });
 
@@ -283,10 +285,11 @@ describe('WorkLogExpressionParser', () => {
         .withWorkload(SOME_WORKLOAD)
         .withDate(SOME_DATE)
         .withProject(SOME_PROJECT)
+        .withProject(PROJECTS_TAG)
         .build();
 
     expect(workLogExpressionParser.isValid(workLogExpression)).toBeTruthy();
-    expect(workLogExpressionParser.parse(workLogExpression).tags).toEqual([SOME_PROJECT]);
+    expect(workLogExpressionParser.parse(workLogExpression).tags).toEqual([SOME_PROJECT, PROJECTS_TAG]);
     expect(workLogExpressionParser.parse(workLogExpression).workload).toEqual(SOME_WORKLOAD);
     expect(workLogExpressionParser.parse(workLogExpression).days).toEqual([SOME_DATE]);
   });
@@ -296,10 +299,11 @@ describe('WorkLogExpressionParser', () => {
         .withDate(SOME_DATE)
         .withWorkload(SOME_WORKLOAD)
         .withProject(SOME_PROJECT)
+        .withProject(PROJECTS_TAG)
         .build();
 
     expect(workLogExpressionParser.isValid(workLogExpression)).toBeTruthy();
-    expect(workLogExpressionParser.parse(workLogExpression).tags).toEqual([SOME_PROJECT]);
+    expect(workLogExpressionParser.parse(workLogExpression).tags).toEqual([SOME_PROJECT, PROJECTS_TAG]);
     expect(workLogExpressionParser.parse(workLogExpression).workload).toEqual(SOME_WORKLOAD);
     expect(workLogExpressionParser.parse(workLogExpression).days).toEqual([SOME_DATE]);
   });
@@ -308,11 +312,12 @@ describe('WorkLogExpressionParser', () => {
     const workLogExpression = new Expression()
         .withDate(SOME_DATE)
         .withProject(SOME_PROJECT)
+        .withProject(PROJECTS_TAG)
         .withWorkload(SOME_WORKLOAD)
         .build();
 
     expect(workLogExpressionParser.isValid(workLogExpression)).toBeTruthy();
-    expect(workLogExpressionParser.parse(workLogExpression).tags).toEqual([SOME_PROJECT]);
+    expect(workLogExpressionParser.parse(workLogExpression).tags).toEqual([SOME_PROJECT, PROJECTS_TAG]);
     expect(workLogExpressionParser.parse(workLogExpression).workload).toEqual(SOME_WORKLOAD);
     expect(workLogExpressionParser.parse(workLogExpression).days).toEqual([SOME_DATE]);
   });
@@ -320,12 +325,13 @@ describe('WorkLogExpressionParser', () => {
   it('parses work log in order: project, workload, date', () => {
     const workLogExpression = new Expression()
         .withProject(SOME_PROJECT)
+        .withProject(PROJECTS_TAG)
         .withWorkload(SOME_WORKLOAD)
         .withDate(SOME_DATE)
         .build();
 
     expect(workLogExpressionParser.isValid(workLogExpression)).toBeTruthy();
-    expect(workLogExpressionParser.parse(workLogExpression).tags).toEqual([SOME_PROJECT]);
+    expect(workLogExpressionParser.parse(workLogExpression).tags).toEqual([SOME_PROJECT, PROJECTS_TAG]);
     expect(workLogExpressionParser.parse(workLogExpression).workload).toEqual(SOME_WORKLOAD);
     expect(workLogExpressionParser.parse(workLogExpression).days).toEqual([SOME_DATE]);
   });
@@ -333,12 +339,13 @@ describe('WorkLogExpressionParser', () => {
   it('parses work log in order: project, date, workload', () => {
     const workLogExpression = new Expression()
         .withProject(SOME_PROJECT)
+        .withProject(PROJECTS_TAG)
         .withDate(SOME_DATE)
         .withWorkload(SOME_WORKLOAD)
         .build();
 
     expect(workLogExpressionParser.isValid(workLogExpression)).toBeTruthy();
-    expect(workLogExpressionParser.parse(workLogExpression).tags).toEqual([SOME_PROJECT]);
+    expect(workLogExpressionParser.parse(workLogExpression).tags).toEqual([SOME_PROJECT, PROJECTS_TAG]);
     expect(workLogExpressionParser.parse(workLogExpression).workload).toEqual(SOME_WORKLOAD);
     expect(workLogExpressionParser.parse(workLogExpression).days).toEqual([SOME_DATE]);
   });
@@ -347,27 +354,30 @@ describe('WorkLogExpressionParser', () => {
     const workLogExpression = new Expression()
         .withDate(SOME_DATE)
         .withProject(SOME_PROJECT)
+        .withProject(PROJECTS_TAG)
         .build();
 
     expect(workLogExpressionParser.isValid(workLogExpression)).toBeTruthy();
-    expect(workLogExpressionParser.parse(workLogExpression).tags).toEqual([SOME_PROJECT]);
+    expect(workLogExpressionParser.parse(workLogExpression).tags).toEqual([SOME_PROJECT, PROJECTS_TAG]);
     expect(workLogExpressionParser.parse(workLogExpression).days).toEqual([SOME_DATE]);
   });
 
   it('parses work log in order: project, workload', () => {
     const workLogExpression = new Expression()
         .withProject(SOME_PROJECT)
+        .withProject(PROJECTS_TAG)
         .withWorkload(SOME_WORKLOAD)
         .build();
 
     expect(workLogExpressionParser.isValid(workLogExpression)).toBeTruthy();
-    expect(workLogExpressionParser.parse(workLogExpression).tags).toEqual([SOME_PROJECT]);
+    expect(workLogExpressionParser.parse(workLogExpression).tags).toEqual([SOME_PROJECT, PROJECTS_TAG]);
     expect(workLogExpressionParser.parse(workLogExpression).workload).toEqual(SOME_WORKLOAD);
   });
 
   it('parses work log with dates range', () => {
     const workLogExpression = new Expression()
         .withProject(SOME_PROJECT)
+        .withProject(PROJECTS_TAG)
         .withWorkload(SOME_WORKLOAD)
         .withDateRange('2019/03/01', '2019/03/03')
         .build();
@@ -379,6 +389,7 @@ describe('WorkLogExpressionParser', () => {
   it('parses work log with named dates range', () => {
     const workLogExpression = new Expression()
         .withProject(SOME_PROJECT)
+        .withProject(PROJECTS_TAG)
         .withWorkload(SOME_WORKLOAD)
         .withDateRange('today', 't+1')
         .build();
@@ -390,6 +401,7 @@ describe('WorkLogExpressionParser', () => {
   it('parses work log with inverted range', () => {
     const workLogExpression = new Expression()
         .withProject(SOME_PROJECT)
+        .withProject(PROJECTS_TAG)
         .withWorkload(SOME_WORKLOAD)
         .withDateRange('tomorrow', 'today')
         .build();
@@ -401,6 +413,7 @@ describe('WorkLogExpressionParser', () => {
   it('parses work log with range of single day', () => {
     const workLogExpression = new Expression()
         .withProject(SOME_PROJECT)
+        .withProject(PROJECTS_TAG)
         .withWorkload(SOME_WORKLOAD)
         .withDateRange('today', 'today')
         .build();

--- a/src/workLogExpressionParser/WorkLogExpressionParser.ts
+++ b/src/workLogExpressionParser/WorkLogExpressionParser.ts
@@ -25,7 +25,7 @@ export class WorkLogExpressionParser {
   }
 
   isValid(expression: string): boolean {
-    return this.parse(expression).valid;
+    return this.parse(expression).validate().valid;
   }
 
   private parseExpression(expression: string): ParsedWorkLog {


### PR DESCRIPTION
Added validation of tags:
- exactly one "top-level" (#projects, #internal, #sick, #vacation, #vacation-special, #holiday) tag required
- some tags (#projects) require providing an additional tag (#projects #project-name-required)

Automatically adding tag #internal when one of tags #self-dev, #blog, #brown-bag, ... used.

Configuration of the above stuff taken from `src/tagsConfig.json` file.

Fixed an issue with inifinite recursion in `Notifications`.